### PR TITLE
Increase the maximum string length for host in DNS

### DIFF
--- a/src/Namecheap/DnsRecord.php
+++ b/src/Namecheap/DnsRecord.php
@@ -146,7 +146,7 @@ namespace Namecheap
 		 */
 		public function setHost($value)
 		{
-			$this->_data['host'] = (string) substr($value, 0, 70);
+			$this->_data['host'] = (string) substr($value, 0, 200);
 			return $this;
 		}
 
@@ -185,7 +185,7 @@ namespace Namecheap
 		 */
 		public function setData($value)
 		{
-			$this->_data['data'] = (string) substr($value, 0, 70);
+			$this->_data['data'] = (string) substr($value, 0, 200);
 			return $this;
 		}
 


### PR DESCRIPTION
The current DNS record class truncates the host down to 70 characters. When forwarding a domain to a URL over 70 characters, the destination URL is truncated, and the link will not be correct. This commit simply ups the maximum host length to 200 characters.